### PR TITLE
URL直接入力によるnoteの編集ページへのアクセスを制限

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,9 @@
 class NotesController < ApplicationController
   before_action :set_note, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!
+=begint    userとnoteを関連づけたらコメントアウトを外す  
+  before_action :correct_user, only: [:edit, :update] 
+=end
   # GET /notes
   # GET /notes.json
   def index
@@ -77,4 +80,13 @@ class NotesController < ApplicationController
     def note_params
       params.require(:note).permit(:category, :content)
     end
+=begint    userとnoteを関連づけたらコメントアウトを外す
+    def correct_user
+      note = Note.find(params[:id])
+      if !current_user?(note.user)
+        redirect_to root_path, alert: '許可されていないページです'
+      end
+    end
+=end
+
 end

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,5 +1,5 @@
 <% @notes.each do |note| %>
 	
-	<%= link_to note.content, note_path(note)  %>
-	<%= image_tag "/note_images/#{note.image}" %>
+	<li><%= link_to note.content, note_path(note)  %></li>
+	<li><%= image_tag "/note_images/#{note.image}" %></li>
 <% end%>


### PR DESCRIPTION
コメントアウトしている状態なので、userとnoteを関連づけたらコメントアウトを外す